### PR TITLE
Add mopidy.ext plugin to poetry pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,9 @@ flake8 = "^3.8.4"
 setuptools = "^51.0.0"
 Sphinx = "^3.3.1"
 
+[tool.poetry.plugins."mopidy.ext"]
+ytmusic = "mopidy_ytmusic:Extension"
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
This fixes the broken setup by reintroducing the previously present entry_points (from the old setup.py build).