### PR TITLE
Update pytube and ytmusicapi dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,8 @@ license = "Apache-2.0"
 [tool.poetry.dependencies]
 python = "^3.7"
 Mopidy = "^3"
-pytube = "^11.0.2"
-ytmusicapi = "^0.19.1"
+pytube = "^12.0.0"
+ytmusicapi = "^0.20.0"
 
 [tool.poetry.dev-dependencies]
 flake8 = "^3.8.4"


### PR DESCRIPTION
Update pytube to 12.0.0 and ytmusicapi to 0.20.0. This seems to mostly fix ytmusic playback.

I'm still seeing exceptions like the following, but I don't know what causes them, so posting the stack trace here to capture it.
```
Feb 20 11:58:09 musicpi mopidy[1098]: ERROR    [YTMusicBackend-4] mopidy_ytmusic YTMusic failed getting tracks for album "MPREb_aj34NkzH2SZ"
Feb 20 11:58:09 musicpi mopidy[1098]: Traceback (most recent call last):
Feb 20 11:58:09 musicpi mopidy[1098]:   File "/var/lib/mopidy/.local/lib/python3.9/site-packages/mopidy_ytmusic/library.py", line 437, in lookup
Feb 20 11:58:09 musicpi mopidy[1098]:     tracks = self.albumToTracks(res, bId)
Feb 20 11:58:09 musicpi mopidy[1098]:   File "/var/lib/mopidy/.local/lib/python3.9/site-packages/mopidy_ytmusic/library.py", line 904, in albumToTracks
Feb 20 11:58:09 musicpi mopidy[1098]:     songartists = [Artist(name=song["artists"])]
Feb 20 11:58:09 musicpi mopidy[1098]:   File "/usr/lib/python3/dist-packages/mopidy/models/immutable.py", line 159, in __call__
Feb 20 11:58:09 musicpi mopidy[1098]:     instance = super().__call__(*args, **kwargs)
Feb 20 11:58:09 musicpi mopidy[1098]:   File "/usr/lib/python3/dist-packages/mopidy/models/immutable.py", line 35, in __init__
Feb 20 11:58:09 musicpi mopidy[1098]:     self._set_field(key, value)
Feb 20 11:58:09 musicpi mopidy[1098]:   File "/usr/lib/python3/dist-packages/mopidy/models/immutable.py", line 188, in _set_field
Feb 20 11:58:09 musicpi mopidy[1098]:     object.__setattr__(self, name, value)
Feb 20 11:58:09 musicpi mopidy[1098]:   File "/usr/lib/python3/dist-packages/mopidy/models/fields.py", line 50, in __set__
Feb 20 11:58:09 musicpi mopidy[1098]:     value = self.validate(value)
Feb 20 11:58:09 musicpi mopidy[1098]:   File "/usr/lib/python3/dist-packages/mopidy/models/fields.py", line 34, in validate
Feb 20 11:58:09 musicpi mopidy[1098]:     raise TypeError(
Feb 20 11:58:09 musicpi mopidy[1098]: TypeError: Expected name to be a <class 'str'>, not [{'name': 'Ebri Knight', 'id': 'UC1n7SLx5qYPP1HzKh-rvyng'}]
```