### PR TITLE
Convert auth_json from String to Path

### DIFF
--- a/mopidy_ytmusic/__init__.py
+++ b/mopidy_ytmusic/__init__.py
@@ -20,7 +20,7 @@ class Extension(ext.Extension):
 
     def get_config_schema(self):
         schema = super().get_config_schema()
-        schema["auth_json"] = config.String(optional=True)
+        schema["auth_json"] = config.Path(optional=True)
         schema["auto_playlist_refresh"] = config.Integer(
             minimum=0, optional=True
         )


### PR DESCRIPTION
The practical difference is that after this the "standard" path expansions work (see https://github.com/mopidy/mopidy/blob/3ecbc988d7965a391a43297c16b295b4190043f3/mopidy/config/types.py#L422 ). These in turn allow sharing a config file between users that have different names and home dirs.