### PR TITLE
Fix bug in album track listing

### DIFF
--- a/mopidy_ytmusic/library.py
+++ b/mopidy_ytmusic/library.py
@@ -901,7 +901,7 @@ class YTMusicLibraryProvider(backend.LibraryProvider):
                 ):
                     songartists = artists
                 else:
-                    songartists = [Artist(name=song["artists"])]
+                    songartists = [Artist(name=artistname)]
                 self.TRACKS[song["videoId"]] = Track(
                     uri=f"ytmusic:track:{song['videoId']}",
                     name=song["title"],


### PR DESCRIPTION
Trying to list the tracks in an album borks with this stack trace:

```
   ERROR    [HttpServer] mopidy_iris.handlers local variable 'data' referenced before assignment
   ERROR    [YTMusicBackend-3 (_actor_loop)] mopidy_ytmusic YTMusic failed getting tracks for album "xxx"
   Traceback (most recent call last):
     File "/usr/local/lib/python3.10/dist-packages/mopidy_ytmusic/library.py", line 437, in lookup
       tracks = self.albumToTracks(res, bId)
     File "/usr/local/lib/python3.10/dist-packages/mopidy_ytmusic/library.py", line 904, in albumToTracks
       songartists = [Artist(name=song["artists"])]
     File "/usr/lib/python3/dist-packages/mopidy/models/immutable.py", line 159, in __call__
       instance = super().__call__(*args, **kwargs)
     File "/usr/lib/python3/dist-packages/mopidy/models/immutable.py", line 35, in __init__
         self._set_field(key, value)
     File "/usr/lib/python3/dist-packages/mopidy/models/immutable.py", line 188, in _set_field
       object.__setattr__(self, name, value)
     File "/usr/lib/python3/dist-packages/mopidy/models/fields.py", line 50, in __set__
       value = self.validate(value)
     File "/usr/lib/python3/dist-packages/mopidy/models/fields.py", line 34, in validate
       raise TypeError(
     TypeError: Expected name to be a <class 'str'>, not [{'name': 'blah', 'id': None}]
```

This was an apparent typo since the type validation clearly expects a
string and not the full Artist object.