### PR TITLE
Allow for ytmusicapi 1.0.0

### DIFF
--- a/mopidy_ytmusic/__init__.py
+++ b/mopidy_ytmusic/__init__.py
@@ -21,6 +21,7 @@ class Extension(ext.Extension):
     def get_config_schema(self):
         schema = super().get_config_schema()
         schema["auth_json"] = config.Path(optional=True)
+        schema["oauth_json"] = config.Path(optional=True)
         schema["auto_playlist_refresh"] = config.Integer(
             minimum=0, optional=True
         )

--- a/mopidy_ytmusic/backend.py
+++ b/mopidy_ytmusic/backend.py
@@ -16,7 +16,7 @@ from ytmusicapi.navigation import (
     TITLE_TEXT,
     nav,
 )
-from ytmusicapi.ytmusic import YTMusic
+from ytmusicapi import setup
 
 from mopidy_ytmusic import logger
 
@@ -62,9 +62,9 @@ class YTMusicBackend(
             self.auth = True
 
         if self.auth:
-            self.api = YTMusic(self._ytmusicapi_auth_json)
+            self.api = setup(self._ytmusicapi_auth_json)
         else:
-            self.api = YTMusic()
+            self.api = setup()
 
         self.playback = YTMusicPlaybackProvider(audio=audio, backend=self)
         self.library = YTMusicLibraryProvider(backend=self)

--- a/mopidy_ytmusic/backend.py
+++ b/mopidy_ytmusic/backend.py
@@ -67,9 +67,9 @@ class YTMusicBackend(
             self.oauth = True
 
         if self.auth and not self.oauth:
-            self.api = YTMusic(self._ytmusicapi_auth_json)
+            self.api = YTMusic(auth=self._ytmusicapi_auth_json)
         elif self.oauth:
-            self.api = YTMusic(self._ytmusicapi_oauth_json)
+            self.api = YTMusic(auth=self._ytmusicapi_oauth_json)
         else:
             self.api = YTMusic()
 

--- a/mopidy_ytmusic/backend.py
+++ b/mopidy_ytmusic/backend.py
@@ -16,7 +16,7 @@ from ytmusicapi.navigation import (
     TITLE_TEXT,
     nav,
 )
-from ytmusicapi import setup
+from ytmusicapi import YTMusic
 
 from mopidy_ytmusic import logger
 
@@ -36,6 +36,7 @@ class YTMusicBackend(
         self.audio = audio
         self.uri_schemes = ["ytmusic"]
         self.auth = False
+        self.oauth = False
 
         self._auto_playlist_refresh_rate = (
             config["ytmusic"]["auto_playlist_refresh"] * 60
@@ -61,10 +62,16 @@ class YTMusicBackend(
             self._ytmusicapi_auth_json = config["ytmusic"]["auth_json"]
             self.auth = True
 
-        if self.auth:
-            self.api = setup(self._ytmusicapi_auth_json)
+        if config["ytmusic"]["oauth_json"]:
+            self._ytmusicapi_oauth_json = config["ytmusic"]["oauth_json"]
+            self.oauth = True
+
+        if self.auth and not self.oauth:
+            self.api = YTMusic(self._ytmusicapi_auth_json)
+        elif self.oauth:
+            self.api = YTMusic(self._ytmusicapi_oauth_json)
         else:
-            self.api = setup()
+            self.api = YTMusic()
 
         self.playback = YTMusicPlaybackProvider(audio=audio, backend=self)
         self.library = YTMusicLibraryProvider(backend=self)
@@ -103,6 +110,7 @@ class YTMusicBackend(
     def _get_youtube_player(self):
         # Refresh our js player URL so YDL can decode the signature correctly.
         try:
+            self.api.headers.pop('filepath', None)
             response = requests.get(
                 "https://music.youtube.com",
                 headers=self.api.headers,

--- a/mopidy_ytmusic/command.py
+++ b/mopidy_ytmusic/command.py
@@ -17,27 +17,20 @@ class SetupCommand(commands.Command):
     help = "Generate auth.json"
 
     def run(self, args, config):
-        from ytmusicapi import YTMusic
+        from ytmusicapi.setup import setup_oauth
 
         filepath = input(
             "Enter the path where you want to save auth.json [default=current dir]: "
         )
         if not filepath:
             filepath = os.getcwd()
-        path = Path(filepath + "/auth.json")
+        path = Path(filepath + "/oauth.json")
         print('Using "' + str(path) + '"')
         if path.exists():
             print("File already exists!")
             return 1
-        print(
-            "Open Youtube Music, open developer tools (F12), go to Network tab,"
-        )
-        print(
-            'right click on a POST request and choose "Copy request headers".'
-        )
-        print("Then paste (CTRL+SHIFT+V) them here and press CTRL+D.")
         try:
-            print(YTMusic(filepath=str(path)))
+            setup_oauth(filepath=str(path))
         except Exception:
             logger.exception("YTMusic setup failed")
             return 1
@@ -54,7 +47,7 @@ class ReSetupCommand(commands.Command):
     help = "Regenerate auth.json"
 
     def run(self, args, config):
-        from ytmusicapi import YTMusic
+        from ytmusicapi.setup import setup_oauth
 
         path = config["ytmusic"]["auth_json"]
         usingOauth = False

--- a/mopidy_ytmusic/command.py
+++ b/mopidy_ytmusic/command.py
@@ -47,7 +47,7 @@ class ReSetupCommand(commands.Command):
     help = "Regenerate auth.json"
 
     def run(self, args, config):
-        from ytmusicapi.setup import setup_oauth
+        from ytmusicapi import YTMusic
 
         path = config["ytmusic"]["auth_json"]
         usingOauth = False

--- a/mopidy_ytmusic/command.py
+++ b/mopidy_ytmusic/command.py
@@ -17,7 +17,7 @@ class SetupCommand(commands.Command):
     help = "Generate auth.json"
 
     def run(self, args, config):
-        from ytmusicapi.ytmusic import YTMusic
+        from ytmusicapi import setup
 
         filepath = input(
             "Enter the path where you want to save auth.json [default=current dir]: "
@@ -37,7 +37,7 @@ class SetupCommand(commands.Command):
         )
         print("Then paste (CTRL+SHIFT+V) them here and press CTRL+D.")
         try:
-            print(YTMusic.setup(filepath=str(path)))
+            print(setup(filepath=str(path)))
         except Exception:
             logger.exception("YTMusic setup failed")
             return 1
@@ -54,7 +54,7 @@ class ReSetupCommand(commands.Command):
     help = "Regenerate auth.json"
 
     def run(self, args, config):
-        from ytmusicapi.ytmusic import YTMusic
+        from ytmusicapi import setup
 
         path = config["ytmusic"]["auth_json"]
         if not path:
@@ -69,7 +69,7 @@ class ReSetupCommand(commands.Command):
         )
         print("Then paste (CTRL+SHIFT+V) them here and press CTRL+D.")
         try:
-            print(YTMusic.setup(filepath=str(path)))
+            print(setup(filepath=str(path)))
         except Exception:
             logger.exception("YTMusic setup failed")
             return 1

--- a/mopidy_ytmusic/command.py
+++ b/mopidy_ytmusic/command.py
@@ -76,7 +76,7 @@ class ReSetupCommand(commands.Command):
         else:
             print("Updating via oauth, follow the instructions from ytmusicapi")
         try:
-            print(YTMusic(path))
+            print(YTMusic(auth=path))
         except Exception:
             logger.exception("YTMusic setup failed")
             return 1

--- a/mopidy_ytmusic/command.py
+++ b/mopidy_ytmusic/command.py
@@ -17,7 +17,7 @@ class SetupCommand(commands.Command):
     help = "Generate auth.json"
 
     def run(self, args, config):
-        from ytmusicapi import setup
+        from ytmusicapi import YTMusic
 
         filepath = input(
             "Enter the path where you want to save auth.json [default=current dir]: "
@@ -37,7 +37,7 @@ class SetupCommand(commands.Command):
         )
         print("Then paste (CTRL+SHIFT+V) them here and press CTRL+D.")
         try:
-            print(setup(filepath=str(path)))
+            print(YTMusic(filepath=str(path)))
         except Exception:
             logger.exception("YTMusic setup failed")
             return 1
@@ -54,22 +54,29 @@ class ReSetupCommand(commands.Command):
     help = "Regenerate auth.json"
 
     def run(self, args, config):
-        from ytmusicapi import setup
+        from ytmusicapi import YTMusic
 
         path = config["ytmusic"]["auth_json"]
+        usingOauth = False
         if not path:
             logger.error("auth_json path not defined in config")
             return 1
+        if config["ytmusic"]["oauth_json"] is not None:
+            path = config["ytmusic"]["oauth_json"]
+            usingOauth = True
         print('Updating credentials in  "' + str(path) + '"')
-        print(
-            "Open Youtube Music, open developer tools (F12), go to Network tab,"
-        )
-        print(
-            'right click on a POST request and choose "Copy request headers".'
-        )
-        print("Then paste (CTRL+SHIFT+V) them here and press CTRL+D.")
+        if not usingOauth:
+            print(
+                "Open Youtube Music, open developer tools (F12), go to Network tab,"
+            )
+            print(
+                'right click on a POST request and choose "Copy request headers".'
+            )
+            print("Then paste (CTRL+SHIFT+V) them here and press CTRL+D.")
+        else:
+            print("Updating via oauth, follow the instructions from ytmusicapi")
         try:
-            print(setup(filepath=str(path)))
+            print(YTMusic(path))
         except Exception:
             logger.exception("YTMusic setup failed")
             return 1

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ package_data = {"": ["*"]}
 install_requires = [
     "Mopidy>=3,<4",
     "pytube>=12.1.0,<13.0.0",
-    "ytmusicapi>=0.22.0,<0.30.0",
+    "ytmusicapi>=0.22.0,<2.0.0",
 ]
 
 entry_points = {"mopidy.ext": ["ytmusic = mopidy_ytmusic:Extension"]}

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ package_data = {"": ["*"]}
 
 install_requires = [
     "Mopidy>=3,<4",
-    "pytube>=12.1.0,<13.0.0",
+    "pytube>=12.1.0",
     "ytmusicapi>=0.22.0,<2.0.0",
 ]
 


### PR DESCRIPTION
ytmusicapi recently updated to 1.0.0 on Arch. I tested locally and it seems to still be in working order with 0.25.0. [I did also update the authentication to follow the newer import style](https://github.com/sigma67/ytmusicapi/releases/tag/1.0.0)

I'm not too familiar with Python development, but I believe this should all be working. If I need to update anything else please let me know.

This also now includes OAuth capabilities from ytmusicapi