### PR TITLE
Make artists key check more robust

### DIFF
--- a/mopidy_ytmusic/library.py
+++ b/mopidy_ytmusic/library.py
@@ -730,7 +730,7 @@ class YTMusicLibraryProvider(backend.LibraryProvider):
                         else track["length"]
                     ).split(":")
                 artists = []
-                if "artists" in track:
+                if "artists" in track and track["artists"] is not None:
                     for a in track["artists"]:
                         if a["id"] not in self.ARTISTS:
                             self.ARTISTS[a["id"]] = Artist(


### PR DESCRIPTION
This allows it to work for uploaded tracks which have `None` for `artists`.

Fixes #82.